### PR TITLE
Load children in order

### DIFF
--- a/loadConn.go
+++ b/loadConn.go
@@ -9,18 +9,19 @@ type Connection struct {
 }
 
 type IKEConf struct {
-	LocalAddrs  []string `json:"local_addrs"`
-	RemoteAddrs []string `json:"remote_addrs,omitempty"`
-	Proposals   []string `json:"proposals,omitempty"`
-	Version     string   `json:"version"` //1 for ikev1, 0 for ikev1 & ikev2
-	Encap       string   `json:"encap"`   //yes,no
-	KeyingTries string   `json:"keyingtries"`
-	//	RekyTime   string                 `json:"rekey_time"`
-	DPDDelay   string                   `json:"dpd_delay,omitempty"`
-	LocalAuth  AuthConf                 `json:"local"`
-	RemoteAuth AuthConf                 `json:"remote"`
-	Pools      []string                 `json:"pools,omitempty"`
-	Children   []map[string]ChildSAConf `json:"children"`
+	LocalAddrs  []string                 `json:"local_addrs"`
+	RemoteAddrs []string                 `json:"remote_addrs,omitempty"`
+	Proposals   []string                 `json:"proposals,omitempty"`
+	Version     string                   `json:"version"` //1 for ikev1, 0 for ikev1 & ikev2
+	Encap       string                   `json:"encap"`   //yes,no
+	KeyingTries string                   `json:"keyingtries"`
+	RekeyTime   string                   `json:"rekey_time"`
+	ReauthTime  string                   `json:"reauth_time"`
+	DPDDelay    string                   `json:"dpd_delay,omitempty"`
+	LocalAuth   AuthConf                 `json:"local"`
+	RemoteAuth  AuthConf                 `json:"remote"`
+	Pools       []string                 `json:"pools,omitempty"`
+	Children    []map[string]ChildSAConf `json:"children"`
 }
 
 type AuthConf struct {

--- a/loadConn.go
+++ b/loadConn.go
@@ -16,11 +16,11 @@ type IKEConf struct {
 	Encap       string   `json:"encap"`   //yes,no
 	KeyingTries string   `json:"keyingtries"`
 	//	RekyTime   string                 `json:"rekey_time"`
-	DPDDelay   string                 `json:"dpd_delay,omitempty"`
-	LocalAuth  AuthConf               `json:"local"`
-	RemoteAuth AuthConf               `json:"remote"`
-	Pools      []string               `json:"pools,omitempty"`
-	Children   map[string]ChildSAConf `json:"children"`
+	DPDDelay   string                   `json:"dpd_delay,omitempty"`
+	LocalAuth  AuthConf                 `json:"local"`
+	RemoteAuth AuthConf                 `json:"remote"`
+	Pools      []string                 `json:"pools,omitempty"`
+	Children   []map[string]ChildSAConf `json:"children"`
 }
 
 type AuthConf struct {


### PR DESCRIPTION
The Marshalling and Unmarshalling of the JSON to and from concrete structs means that the `children` can sometimes get out of order. 

This is a breaking change as it alters the type of `Children` to be a `slice`.

When children is processed it is iterated through in order.